### PR TITLE
Add support for dpr parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The goal of this package is to supply a full comprehending API supporting all th
 - [ ] Mask Image
 - [ ] Noise Reduction
 - [ ] PDF
-- [ ] Pixel Density
+- [x] Pixel Density
 - [x] Rotation
 - [x] Size
 - [x] Stylize
@@ -70,6 +70,9 @@ The goal of this package is to supply a full comprehending API supporting all th
           [ ImgIX.Stylize.blur 20
           , ImgIX.Stylize.sepia 99
           ]
+      |> ImgIX.pixelDensities
+          [ ImgIX.PixelDensity.dpr 2
+          ]
       |> ImgIX.automatics
           [ ImgIX.Automatic.fileFormat
           ]
@@ -77,7 +80,7 @@ The goal of this package is to supply a full comprehending API supporting all th
 
 ```
 
-![result example b](https://static-a.imgix.net/woman.jpg?w=200&h=200&fit=facearea&rot=12&flip=h&bri=20&auto=format&blur=20&sepia=99)
+![result example b](https://static-a.imgix.net/woman.jpg?w=200&h=200&fit=facearea&dpr=2&rot=12&flip=h&bri=20&auto=format&blur=20&sepia=99)
 
 
 ## Usage example Text

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "tricycle/elm-imgix",
     "summary": "A wrapper around ImgIX image API for Elm",
     "license": "BSD-3-Clause",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "exposed-modules": [
         "ImgIX",
         "ImgIX.Adjustment",

--- a/elm.json
+++ b/elm.json
@@ -8,6 +8,7 @@
         "ImgIX",
         "ImgIX.Adjustment",
         "ImgIX.Automatic",
+        "ImgIX.PixelDensity",
         "ImgIX.Size",
         "ImgIX.Rotation",
         "ImgIX.Stylize",

--- a/src/ImgIX.elm
+++ b/src/ImgIX.elm
@@ -1,6 +1,7 @@
 module ImgIX exposing
     ( ImgIX
     , fromUrl, fromString
+    , pixelDensity, pixelDensities
     , size, sizes
     , rotation, rotations
     , adjust, adjustments
@@ -22,6 +23,11 @@ module ImgIX exposing
 # Creation
 
 @docs fromUrl, fromString
+
+
+# Pixel Density
+
+@docs pixelDensity, pixelDensities
 
 
 # Size
@@ -69,6 +75,7 @@ import Html as Html exposing (Attribute, img)
 import Html.Attributes as HtmlAttr exposing (src)
 import ImgIX.Adjustment exposing (Adjustment, toQueryParameters)
 import ImgIX.Automatic exposing (Automatic, toQueryParameter)
+import ImgIX.PixelDensity exposing (PixelDensity, toQueryParameters)
 import ImgIX.Rotation exposing (Rotation, toQueryParameters)
 import ImgIX.Size exposing (Size, toQueryParameters)
 import ImgIX.Stylize exposing (Stylize, toQueryParameters)
@@ -95,6 +102,28 @@ fromUrl url =
 fromString : String -> Maybe ImgIX
 fromString =
     Maybe.map fromUrl << Url.fromString
+
+
+
+-- Pixel Density
+
+
+{-| Control the pixel density of an ImgIX
+Check the ImgIX.PixelDensity module for all the available options.
+-}
+pixelDensity : PixelDensity -> ImgIX -> ImgIX
+pixelDensity x (ImgIX url imgIXOptions) =
+    ImgIX url
+        { imgIXOptions
+            | pixelDensity = x :: imgIXOptions.pixelDensity
+        }
+
+
+{-| Apply a list of PixelDensity operations
+-}
+pixelDensities : List PixelDensity -> ImgIX -> ImgIX
+pixelDensities =
+    fold pixelDensity
 
 
 
@@ -241,6 +270,9 @@ toUrl (ImgIX url imgIXOptions) =
         sizeQueryParameters =
             ImgIX.Size.toQueryParameters imgIXOptions.size
 
+        pixelDensityParameters =
+            ImgIX.PixelDensity.toQueryParameters imgIXOptions.pixelDensity
+
         rotationQueryParameters =
             ImgIX.Rotation.toQueryParameters imgIXOptions.rotation
 
@@ -259,6 +291,7 @@ toUrl (ImgIX url imgIXOptions) =
         query =
             UrlBuilder.toQuery
                 (sizeQueryParameters
+                    ++ pixelDensityParameters
                     ++ rotationQueryParameters
                     ++ adjustmentQueryParameters
                     ++ [ automaticQueryParameter ]
@@ -298,6 +331,7 @@ toHtmlWithAttributes listOfAttributes imgix =
 
 type alias ImgIXOptions =
     { size : List Size
+    , pixelDensity : List PixelDensity
     , adjustment : List Adjustment
     , automatic : List Automatic
     , rotation : List Rotation
@@ -347,6 +381,7 @@ rgba red green blue alpha =
 emptyImgIXOptions : ImgIXOptions
 emptyImgIXOptions =
     { size = []
+    , pixelDensity = []
     , adjustment = []
     , automatic = []
     , rotation = []

--- a/src/ImgIX/PixelDensity.elm
+++ b/src/ImgIX/PixelDensity.elm
@@ -64,7 +64,5 @@ toQueryParameters pixelDensityOperations =
 
 
 toQueryParameters_ : PixelDensity -> List ( String, String )
-toQueryParameters_ a =
-    case a of
-        Dpr density ->
-            [ ( "dpr", String.fromInt density ) ]
+toQueryParameters_ (Dpr density) =
+    [ ( "dpr", String.fromInt density ) ]

--- a/src/ImgIX/PixelDensity.elm
+++ b/src/ImgIX/PixelDensity.elm
@@ -1,0 +1,70 @@
+module ImgIX.PixelDensity exposing
+    ( PixelDensity
+    , dpr
+    , toQueryParameters
+    )
+
+{-| Controls the output density of your image, so you can serve images at the correct density for every user's device from a single master image.
+
+[ImgIX documentation for PixelDensity](https://docs.imgix.com/apis/rendering/pixel-density)
+
+@docs PixelDensity
+
+
+# Device Pixel Ratio
+
+Device pixel ratio (DPR) is an easy way to convert between device-independent pixels and device pixels (also called "CSS pixels"), so that high-DPR images are only delivered to devices that can support them.
+This makes images faster and saves bandwidth for users with lower-DPR devices, while delivering the expected crispness of high-DPR imagery to those devices.
+
+@docs dpr
+
+
+# Applying
+
+@docs toQueryParameters
+
+-}
+
+import List.Extra as ListExtra exposing (groupWhile)
+import Url.Builder as UrlBuilder exposing (QueryParameter, string)
+
+
+{-| The PixelDensity type
+-}
+type PixelDensity
+    = Dpr Int
+
+
+
+-- Device Pixel Ratio
+
+
+{-| The density of the output image.
+-}
+dpr : Int -> PixelDensity
+dpr =
+    Dpr
+
+
+
+-- Applying
+
+
+{-| Takes a list of pixel density operations and turns it in to a list of query parameters that ImgIX understands
+-}
+toQueryParameters : List PixelDensity -> List UrlBuilder.QueryParameter
+toQueryParameters pixelDensityOperations =
+    List.foldl (\a b -> toQueryParameters_ a ++ b) [] pixelDensityOperations
+        |> ListExtra.groupWhile (\( a, _ ) ( b, _ ) -> a == b)
+        |> List.map
+            (\( ( a, b ), c ) ->
+                ( a, String.join "," <| (b :: List.map Tuple.second c) )
+            )
+        |> List.map (\( a, b ) -> UrlBuilder.string a b)
+
+
+toQueryParameters_ : PixelDensity -> List ( String, String )
+toQueryParameters_ a =
+    case a of
+        Dpr density ->
+            [ ( "dpr", String.fromInt density ) ]


### PR DESCRIPTION
This PR adds support for the pixel density operations, of which there currently only exists one, `dpr`:
https://docs.imgix.com/apis/rendering/pixel-density/