### PR TITLE
Add support for output quality (q) and lossless parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The goal of this package is to supply a full comprehending API supporting all th
       |> ImgIX.pixelDensities
           [ ImgIX.PixelDensity.dpr 2
           ]
+      |> ImgIX.formats
+          [ ImgIX.Format.q 60 ]
       |> ImgIX.automatics
           [ ImgIX.Automatic.fileFormat
           ]
@@ -80,7 +82,7 @@ The goal of this package is to supply a full comprehending API supporting all th
 
 ```
 
-![result example b](https://static-a.imgix.net/woman.jpg?w=200&h=200&fit=facearea&dpr=2&rot=12&flip=h&bri=20&auto=format&blur=20&sepia=99)
+![result example b](https://static-a.imgix.net/woman.jpg?w=200&h=200&fit=facearea&dpr=2&q=60&rot=12&flip=h&bri=20&auto=format&blur=20&sepia=99)
 
 
 ## Usage example Text

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ The goal of this package is to supply a full comprehending API supporting all th
       |> ImgIX.pixelDensities
           [ ImgIX.PixelDensity.dpr 2
           ]
-      |> ImgIX.formats
-          [ ImgIX.Format.q 60 ]
+      |> ImgIX.format
+          [ ImgIX.Format.q 60,
+          , ImgIX.Format.lossless False
+          ]
       |> ImgIX.automatics
           [ ImgIX.Automatic.fileFormat
           ]
-
-
 ```
 
 ![result example b](https://static-a.imgix.net/woman.jpg?w=200&h=200&fit=facearea&dpr=2&q=60&rot=12&flip=h&bri=20&auto=format&blur=20&sepia=99)

--- a/elm.json
+++ b/elm.json
@@ -8,9 +8,10 @@
         "ImgIX",
         "ImgIX.Adjustment",
         "ImgIX.Automatic",
+        "ImgIX.Format",
         "ImgIX.PixelDensity",
-        "ImgIX.Size",
         "ImgIX.Rotation",
+        "ImgIX.Size",
         "ImgIX.Stylize",
         "ImgIX.Text"
     ],

--- a/elm.json
+++ b/elm.json
@@ -21,6 +21,7 @@
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0",
         "elm-community/list-extra": "8.2.0 <= v < 9.0.0",
+        "elm-community/maybe-extra": "5.2.0 <= v < 6.0.0",
         "truqu/elm-base64": "2.0.4 <= v < 3.0.0"
     },
     "test-dependencies": {

--- a/src/ImgIX.elm
+++ b/src/ImgIX.elm
@@ -2,7 +2,7 @@ module ImgIX exposing
     ( ImgIX
     , fromUrl, fromString
     , pixelDensity, pixelDensities
-    , format, formats
+    , format
     , size, sizes
     , rotation, rotations
     , adjust, adjustments
@@ -33,7 +33,7 @@ module ImgIX exposing
 
 # Format
 
-@docs format, formats
+@docs format
 
 
 # Size
@@ -136,19 +136,9 @@ pixelDensities =
 {-| Control the format of an ImgIX
 Check the ImgIX.Format module for all the available options.
 -}
-format : Format -> ImgIX -> ImgIX
-format x (ImgIX url imgIXOptions) =
-    ImgIX url
-        { imgIXOptions
-            | format = x :: imgIXOptions.format
-        }
-
-
-{-| Apply a list of Format operations
--}
-formats : List Format -> ImgIX -> ImgIX
-formats =
-    fold format
+format : List (Format -> Format) -> ImgIX -> ImgIX
+format fs (ImgIX url imgIXOptions) =
+    ImgIX url { imgIXOptions | format = List.foldl (\f a -> f a) imgIXOptions.format fs }
 
 
 
@@ -361,7 +351,7 @@ toHtmlWithAttributes listOfAttributes imgix =
 type alias ImgIXOptions =
     { size : List Size
     , pixelDensity : List PixelDensity
-    , format : List Format
+    , format : Format
     , adjustment : List Adjustment
     , automatic : List Automatic
     , rotation : List Rotation
@@ -412,7 +402,7 @@ emptyImgIXOptions : ImgIXOptions
 emptyImgIXOptions =
     { size = []
     , pixelDensity = []
-    , format = []
+    , format = ImgIX.Format.empty
     , adjustment = []
     , automatic = []
     , rotation = []

--- a/src/ImgIX.elm
+++ b/src/ImgIX.elm
@@ -2,6 +2,7 @@ module ImgIX exposing
     ( ImgIX
     , fromUrl, fromString
     , pixelDensity, pixelDensities
+    , format, formats
     , size, sizes
     , rotation, rotations
     , adjust, adjustments
@@ -28,6 +29,11 @@ module ImgIX exposing
 # Pixel Density
 
 @docs pixelDensity, pixelDensities
+
+
+# Format
+
+@docs format, formats
 
 
 # Size
@@ -75,6 +81,7 @@ import Html as Html exposing (Attribute, img)
 import Html.Attributes as HtmlAttr exposing (src)
 import ImgIX.Adjustment exposing (Adjustment, toQueryParameters)
 import ImgIX.Automatic exposing (Automatic, toQueryParameter)
+import ImgIX.Format exposing (Format, toQueryParameters)
 import ImgIX.PixelDensity exposing (PixelDensity, toQueryParameters)
 import ImgIX.Rotation exposing (Rotation, toQueryParameters)
 import ImgIX.Size exposing (Size, toQueryParameters)
@@ -124,6 +131,24 @@ pixelDensity x (ImgIX url imgIXOptions) =
 pixelDensities : List PixelDensity -> ImgIX -> ImgIX
 pixelDensities =
     fold pixelDensity
+
+
+{-| Control the format of an ImgIX
+Check the ImgIX.Format module for all the available options.
+-}
+format : Format -> ImgIX -> ImgIX
+format x (ImgIX url imgIXOptions) =
+    ImgIX url
+        { imgIXOptions
+            | format = x :: imgIXOptions.format
+        }
+
+
+{-| Apply a list of Format operations
+-}
+formats : List Format -> ImgIX -> ImgIX
+formats =
+    fold format
 
 
 
@@ -273,6 +298,9 @@ toUrl (ImgIX url imgIXOptions) =
         pixelDensityParameters =
             ImgIX.PixelDensity.toQueryParameters imgIXOptions.pixelDensity
 
+        formatParameters =
+            ImgIX.Format.toQueryParameters imgIXOptions.format
+
         rotationQueryParameters =
             ImgIX.Rotation.toQueryParameters imgIXOptions.rotation
 
@@ -292,6 +320,7 @@ toUrl (ImgIX url imgIXOptions) =
             UrlBuilder.toQuery
                 (sizeQueryParameters
                     ++ pixelDensityParameters
+                    ++ formatParameters
                     ++ rotationQueryParameters
                     ++ adjustmentQueryParameters
                     ++ [ automaticQueryParameter ]
@@ -332,6 +361,7 @@ toHtmlWithAttributes listOfAttributes imgix =
 type alias ImgIXOptions =
     { size : List Size
     , pixelDensity : List PixelDensity
+    , format : List Format
     , adjustment : List Adjustment
     , automatic : List Automatic
     , rotation : List Rotation
@@ -382,6 +412,7 @@ emptyImgIXOptions : ImgIXOptions
 emptyImgIXOptions =
     { size = []
     , pixelDensity = []
+    , format = []
     , adjustment = []
     , automatic = []
     , rotation = []

--- a/src/ImgIX/Format.elm
+++ b/src/ImgIX/Format.elm
@@ -37,7 +37,7 @@ Valid values are 1/true and 0/false. When unset or set to an invalid value, loss
 -}
 
 import Maybe.Extra as Maybe
-import Url.Builder as UrlBuilder exposing (QueryParameter, string)
+import Url.Builder as UrlBuilder
 
 
 {-| The Format type

--- a/src/ImgIX/Format.elm
+++ b/src/ImgIX/Format.elm
@@ -1,0 +1,69 @@
+module ImgIX.Format exposing
+    ( Format
+    , q
+    , toQueryParameters
+    )
+
+{-| The format parameters give you control over the output properties of your image across several aspects.
+
+[ImgIX documentation for Format](https://docs.imgix.com/apis/rendering/format)
+
+@docs Format
+
+
+# Output Quality
+
+Controls the output quality of lossy file formats (jpg, pjpg, webp, or jxr).
+
+Valid values are in the range 0 – 100 and the default is 75. Quality can often be set much lower than the default, especially when serving high-DPR images.
+
+@docs q
+
+
+# Applying
+
+@docs toQueryParameters
+
+-}
+
+import List.Extra as ListExtra exposing (groupWhile)
+import Url.Builder as UrlBuilder exposing (QueryParameter, string)
+
+
+{-| The Format type
+-}
+type Format
+    = OutputQuality Int
+
+
+
+-- Device Pixel Ratio
+
+
+{-| The output quality of lossy file formats.
+-}
+q : Int -> Format
+q =
+    OutputQuality
+
+
+
+-- Applying
+
+
+{-| Takes a list of format operations and turns it in to a list of query parameters that ImgIX understands
+-}
+toQueryParameters : List Format -> List UrlBuilder.QueryParameter
+toQueryParameters formatOperations =
+    List.foldl (\a b -> toQueryParameters_ a ++ b) [] formatOperations
+        |> ListExtra.groupWhile (\( a, _ ) ( b, _ ) -> a == b)
+        |> List.map
+            (\( ( a, b ), c ) ->
+                ( a, String.join "," <| (b :: List.map Tuple.second c) )
+            )
+        |> List.map (\( a, b ) -> UrlBuilder.string a b)
+
+
+toQueryParameters_ : Format -> List ( String, String )
+toQueryParameters_ (OutputQuality quality) =
+    [ ( "q", String.fromInt quality ) ]


### PR DESCRIPTION
This PR adds support for the output quality (`q`) and lossless parameters within the Format set:
https://docs.imgix.com/apis/rendering/format